### PR TITLE
Add Flight Feasibility API pair-programming exercise

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ A collection of hands-on coding interview projects organized by language and int
 | Java | Pair Programming | [Bookstore API](java/pair-programming/bookstore-api/) | Spring Boot 4, Java 25, H2, JPA | Done |
 | Java | Pair Programming | [Todo API](java/pair-programming/todo-api/) | Spring Boot 4, Java 25, H2, JPA | Done |
 | Java | Pair Programming | [Delivery Food System](java/pair-programming/delivery-food-system/) | Spring Boot 3.4, Java 21, MongoDB, Kafka | Done |
+| Java | Pair Programming | [Flight Feasibility API](java/pair-programming/flight-feasibility/) | Spring Boot 4, Java 25, Maven | Done |
+
+> **Note on formats:** most projects hand the candidate a working codebase with intentional issues to
+> find and fix. **Flight Feasibility** is different — it is *build from scratch* against a real,
+> deliberately ambiguous assessment brief, with only the HTTP contract provided.
 
 ## Structure
 
@@ -24,7 +29,8 @@ interviews/
 │   ├── pair-programming/
 │   │   ├── bookstore-api/
 │   │   ├── todo-api/
-│   │   └── delivery-food-system/
+│   │   ├── delivery-food-system/
+│   │   └── flight-feasibility/
 │   ├── take-home/
 │   └── system-design/
 ├── python/

--- a/java/pair-programming/flight-feasibility/.gitignore
+++ b/java/pair-programming/flight-feasibility/.gitignore
@@ -1,0 +1,35 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/java/pair-programming/flight-feasibility/.mvn/wrapper/maven-wrapper.properties
+++ b/java/pair-programming/flight-feasibility/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/java/pair-programming/flight-feasibility/INTERVIEW_TASKS.md
+++ b/java/pair-programming/flight-feasibility/INTERVIEW_TASKS.md
@@ -1,0 +1,340 @@
+# Interview Tasks — Flight Feasibility API (Build From Scratch)
+
+This is a **build-from-scratch** challenge. The candidate reads the assessment brief in
+[`README.md`](README.md), works out what the rules mean, and implements them. The app runs and the
+HTTP contract exists; everything behind it is empty.
+
+Pick **1-2 tasks** matching the candidate's level. Let them read the brief and explore the codebase
+for **~10 minutes** before starting.
+
+**Sequencing note:** Tasks 1-3 are the foundation — later tasks assume a working distance calculation
+and endpoint. For a mid or senior candidate who should not spend the session on arithmetic, hand them
+Task 1 as pre-work (or let them stub the distance) and start at Task 5 or 7.
+
+**The brief is deliberately ambiguous.** Boundary wording, the definition of "travelling west", and
+the timezone of the take-off time are all unresolved. Do not resolve them for the candidate — the
+point is to see whether they notice, ask, and commit to a decision. "I chose X because Y" is a full
+pass; guessing silently is not.
+
+---
+
+## Junior Level (15-20 min each)
+
+### Task 1: Calculate the Flight Distance
+
+**Context:** Nothing in the codebase computes distance yet. The brief requires the Haversine formula
+over the departure and arrival coordinates.
+
+**What to do:**
+1. Create a class responsible for calculating great-circle distance in kilometres
+2. Implement the Haversine formula (no geo library — write it yourself)
+3. Unit-test it against known distances
+
+**Acceptance Criteria:**
+- Barcelona `41.3851, 2.1734` → London `51.5074, -0.1278` is about **1,139 km**
+- Barcelona → Sydney `-33.8688, 151.2093` is about **17,180 km**
+- The calculation lives in its own class, not in the controller
+- At least one test asserts a known distance within a stated tolerance
+
+**Hints:**
+- `Math.toRadians()` already exists — no need to write a degrees-to-radians helper
+- Use the Earth's mean radius, 6,371 km
+- Watch out for integer division and for rounding too early
+- Ask them: how accurate is this for a real flight? Is that accuracy good enough here?
+
+---
+
+### Task 2: Implement the Maximum Flight Range Rule
+
+**Context:** The brief defines two passenger bands with different maximum distances. This is the
+simplest of the three rules — get the shape right and the others follow.
+
+**What to do:**
+1. Implement the maximum flight range rule
+2. Decide what happens when a distance is *exactly* equal to a limit, and be ready to justify it
+3. Write unit tests covering both passenger bands
+
+**Acceptance Criteria:**
+- Both passenger bands from the brief are enforced
+- The candidate states their reading of "cannot exceed" and the tests pin it
+- Tests cover each band, not just one
+- No magic numbers in the middle of a condition — named constants at minimum
+
+**Hints:**
+- Re-read the brief's wording for the bands carefully, then say out loud which band a flight with
+  *exactly* 150 passengers belongs to. It is the most commonly failed detail in this exercise
+- Keep the rule out of the controller
+
+---
+
+### Task 3: Wire Up the Endpoint
+
+**Context:** `FlightPlanController.assess()` throws `UnsupportedOperationException`. The brief asks
+for a feasibility verdict plus a list of feedback messages.
+
+**What to do:**
+1. Return a real `FeasibilityResponse` from the endpoint
+2. Report **every** violated rule, not just the first one
+3. Keep the controller thin — parse, delegate, respond
+
+**Acceptance Criteria:**
+- A feasible flight returns `200` with `feasible: true` and empty `feedback`
+- An infeasible flight returns `200` with `feasible: false` and a message per violation
+- A flight breaking two rules produces two messages
+- The controller contains no distance maths and no rule logic
+
+**Hints:**
+- The brief says "a list of feedback messages" — plural, so do not return early on the first failure
+- Discuss: why is an infeasible flight `200` and not `400`? What would `422` mean here?
+- The feedback messages are read by an operator who has to fix the plan — include the offending value
+
+---
+
+### Task 4: Replace System.out.println with Proper Logging
+
+**Context:** `FlightPlanController` logs with `System.out.println()`. This is a common code smell.
+
+**What to do:**
+1. Add an SLF4J logger to the controller
+2. Replace the `System.out.println()` call with an appropriate log level
+3. Use parameterised messages (e.g. `log.info("Assessing flight {}", flightNumber)`)
+
+**Acceptance Criteria:**
+- No `System.out.println()` anywhere in `src/main`
+- Uses `LoggerFactory.getLogger()` (or Lombok's `@Slf4j` if they add Lombok)
+- Log level is appropriate — `info` for a business event, not `error`
+
+**Hints:**
+- SLF4J comes with Spring Boot — no extra dependency needed
+- Ask why string concatenation in a log call is worse than a `{}` placeholder
+- Ask what else is worth logging here, and what must never be logged
+
+---
+
+## Mid-Level (20-25 min each)
+
+### Task 5: Implement the Long-Distance Take-Off Window Rule
+
+**Context:** The brief restricts take-off times for long flights only.
+
+**What to do:**
+1. Implement the rule
+2. Decide exactly which flights the rule applies to, and which times are allowed
+3. Test both sides of every boundary the rule has
+
+**Acceptance Criteria:**
+- The rule only affects the flights the brief says it affects
+- Both ends of the time window are tested, one minute either side
+- A flight of exactly the threshold distance is handled according to a stated decision
+- The rule is independently testable — no Spring context needed
+
+**Hints:**
+- `LocalTime.isBefore()` and `isAfter()` are both strict. The brief says "between 06:00 and 14:00" —
+  does that include 06:00 and 14:00? Make them commit to an answer
+- Same question for the threshold distance: the brief says "longer than 9,000 km", so what happens at
+  exactly 9,000?
+- Ask what timezone 06:00 refers to. There is no right answer in the brief — listen for whether they
+  notice
+
+---
+
+### Task 6: Implement the Westbound Rule
+
+**Context:** The brief adds two conditions for flights "travelling west". It never defines what
+travelling west means.
+
+**What to do:**
+1. Decide how to determine that a flight travels west, using only the data available
+2. Implement both conditions
+3. Make sure the operator can tell **which** of the two conditions failed
+
+**Acceptance Criteria:**
+- The direction test is explained and defended, not just written
+- Both conditions are enforced, and a flight breaking both says so
+- Flights that are not westbound are unaffected by either condition
+- Tests cover a westbound flight, a non-westbound flight, and both failure modes
+
+**Hints:**
+- All they have is two longitudes. Ask what the simplest test is, then ask when it is wrong
+- Prompt if needed: what does their rule say about a flight from Tokyo `139.65` to Los Angeles
+  `-118.24`? Which way does that flight actually go? (Task 12 fixes this — for now, noticing is
+  enough)
+- If one rule class reports one message, a flight that is both too late and too far will hide a
+  problem from the operator. Is that acceptable?
+
+---
+
+### Task 7: Make Adding a Rule Cheap
+
+**Context:** The brief says the solution must be "maintainable and easy to extend". If the three
+rules are `if` blocks in one method, that requirement is not met.
+
+**What to do:**
+1. Introduce an abstraction so each rule is its own unit
+2. Let the application discover the rules rather than hard-coding a list
+3. Refactor the existing rules onto it, keeping all tests green
+
+**Acceptance Criteria:**
+- Adding a fourth rule means **one new class** and no edits to any existing rule or service
+- Each rule can be unit-tested without starting Spring
+- The service that runs the rules does not name a single concrete rule
+- Distance is calculated once per request, not once per rule
+
+**Hints:**
+- Spring will inject every bean of a type into a `List<T>` constructor parameter — that is the whole
+  trick
+- Ask what happens to the order of the feedback messages, and whether they can rely on it
+- Ask them to name the trade-off they just accepted. Every design has one
+- Push back with "isn't an interface overkill for three rules?" and see if they can defend it — the
+  answer is in the brief
+
+---
+
+### Task 8: Add Input Validation
+
+**Context:** The endpoint accepts anything. Send an empty body, a blank flight number, zero
+passengers or a latitude of 500 and it will happily try to assess it.
+
+**What to do:**
+1. Add validation for the fields described in the brief
+2. Return `400` with useful, field-level messages
+3. Report **all** the input problems at once, not just the first
+
+**Acceptance Criteria:**
+- Flight number is required and not blank; passengers must be positive
+- Latitude is within ±90 and longitude within ±180
+- An invalid request returns `400` with a message per problem
+- A valid-but-infeasible request still returns `200` — validation and feasibility stay separate
+
+**Hints:**
+- `spring-boot-starter-validation` is **not** in the `pom.xml` yet — they will need to add it
+- `@Valid` on the controller parameter, constraints on the record components
+- Handle `MethodArgumentNotValidException` in a `@RestControllerAdvice`
+- Ask why the fields in `FlightPlanRequest` are boxed types (`Integer`, `Double`) and what would
+  happen if `departureLatitude` were a primitive `double` and the caller omitted it. The answer is
+  that `0.0` is a perfectly valid coordinate — a real bug
+
+---
+
+### Task 9: Separate Bad Requests from Infeasible Flights
+
+**Context:** Two different failures are easy to conflate: a request the API cannot understand, and a
+flight plan it understands perfectly and rejects.
+
+**What to do:**
+1. Make sure a client mistake never surfaces as a `500`
+2. Give the two cases distinct, deliberate responses
+3. Check what happens today with `"takeOffTime": "25:99"` and with a truncated JSON body
+
+**Acceptance Criteria:**
+- Unparseable input returns `400` with a helpful body, not a stack trace
+- An infeasible flight returns `200` with `feasible: false`
+- No handler swallows genuine server errors silently
+
+**Hints:**
+- `ProblemDetail` (RFC 9457) is built into Spring — worth discussing even if they roll their own
+- Ask what is wrong with `@ExceptionHandler(Exception.class)`. Answer: it converts real bugs into
+  tidy responses with nothing logged, and can shadow Spring's own sensible defaults
+- `HttpMessageNotReadableException` is the one to catch for malformed JSON
+
+---
+
+## Senior Level (25-30 min each)
+
+### Task 10: Add a Brand-New Rule, Live
+
+**Context:** This is the real test of Task 7. The interviewer invents a rule on the spot and the
+candidate implements it while being watched.
+
+**What to do:** Give them **one** of these, and do not let them see it in advance:
+1. *"No take-offs between 23:00 and 05:00."*
+2. *"Aircraft with more than 300 passengers may not fly further than 5,000 km."*
+3. *"Eastbound flights over 10,000 km must take off before 09:00."*
+
+**Acceptance Criteria:**
+- Implemented as one new class with **no edits to existing rules or the service**
+- Comes with its own unit tests, including the boundaries
+- Done in under ten minutes
+
+**Hints:**
+- Watch **which files they open** — that is the actual measurement, not whether it compiles
+- Option 1 is the sharpest: the window spans midnight, so the natural
+  `isAfter(23:00) && isBefore(05:00)` is *always false*. It needs `||`. A test at 02:00 catches it
+  instantly — do they write one?
+- If they have to modify the service to register the rule, revisit Task 7 with them
+
+---
+
+### Task 11: Make the Limits Configurable
+
+**Context:** Operations wants to change the 8,000 km limit without a code change. Today every
+threshold is a constant in the source.
+
+**What to do:**
+1. Move the thresholds into `application.yml`
+2. Bind them type-safely and inject them into the rules
+3. Keep the current values as defaults so nothing breaks
+
+**Acceptance Criteria:**
+- Changing a limit in `application.yml` changes the behaviour with no recompile
+- Configuration is bound to a typed object, not read with raw `@Value` strings scattered about
+- Existing tests still pass, and the rules can still be tested without Spring
+- Invalid configuration is rejected at startup, not on the first request
+
+**Hints:**
+- `@ConfigurationProperties` bound to a record, with `@EnableConfigurationProperties` or
+  `@ConfigurationPropertiesScan`
+- Ask what "without a deploy" really means — this is still a restart. What would runtime changes cost?
+- Ask whether the *rules themselves* should be configurable, and where they would stop
+
+---
+
+### Task 12: Define "Travelling West" Correctly
+
+**Context:** The obvious direction test — comparing the two longitudes — is wrong for flights crossing
+the antimeridian. Tokyo `139.65` → Los Angeles `-118.24` has a smaller arrival longitude, but the
+great-circle route heads **east** across the Pacific.
+
+**What to do:**
+1. Implement a correct direction test
+2. Keep every existing test green
+3. Explain the trade-off between the simple version and the correct one
+
+**Acceptance Criteria:**
+- Tokyo → Los Angeles is **not** classified as westbound
+- Barcelona → London still is
+- Flights on the same meridian are handled deliberately
+- Covered by tests that would fail against the naive implementation
+
+**Hints:**
+- Normalise the longitude difference into (−180, 180] — add or subtract 360 until it is in range —
+  then test the sign
+- Or compute the initial great-circle bearing and check whether it points west
+- Ask what happens at the poles, where longitude is degenerate
+- Ask whether they would have shipped the simple version with a comment, and when that is the right
+  call
+
+---
+
+### Task 13: Make the Feedback Machine-Readable
+
+**Context:** A client team says they are string-matching on the feedback messages to decide what to
+show the user, and it keeps breaking when wording changes. Another team wants the messages in Spanish.
+
+**What to do:**
+1. Give every violation a stable code alongside its human-readable message
+2. Discuss what this does to existing clients and how you would roll it out
+3. Sketch how the same change enables translation
+
+**Acceptance Criteria:**
+- Each violation carries a stable identifier that does not change when wording does
+- The response change is versioned or additive — existing clients are considered explicitly
+- Ordering of the violations is deterministic
+- Translation is possible without touching the rules
+
+**Hints:**
+- A `record Violation(String code, String message)` is the obvious shape — then `feedback` becomes a
+  list of those
+- `MessageSource` plus message keys is how Spring does i18n; the rules should emit keys, not sentences
+- This is where non-deterministic rule ordering from Task 7 becomes a client-visible problem — do they
+  connect the two?

--- a/java/pair-programming/flight-feasibility/README.md
+++ b/java/pair-programming/flight-feasibility/README.md
@@ -1,0 +1,149 @@
+# Flight Feasibility API — Interview Practice
+
+A Spring Boot REST API designed as a **live coding interview practice repository**. Unlike the other
+projects in this repo, this one is a **build-from-scratch** exercise: the app runs, the HTTP contract
+is in place, and everything behind it is empty. The candidate implements the business rules from the
+assessment brief below.
+
+The brief is reproduced **exactly as a real company issued it** — including the parts that are
+ambiguous. Working out what the rules actually mean, asking about the gaps, and defending the
+decisions is a large part of what is being assessed. Do not expect the brief to answer every
+question.
+
+## Tech Stack
+
+- **Java 25**
+- **Spring Boot 4.0.2**
+- **Maven**
+- No database, no external services — everything is in memory
+
+## Getting Started
+
+### Prerequisites
+
+- Java 25+
+- Maven 3.9+ (the wrapper is included)
+
+### Run the Application
+
+```bash
+./mvnw spring-boot:run
+```
+
+The app starts on **http://localhost:8080**.
+
+### Run Tests
+
+```bash
+./mvnw clean test
+```
+
+### Try the Endpoint
+
+```bash
+curl -X POST http://localhost:8080/api/flights/feasibility \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "flightNumber": "IB2570",
+        "takeOffTime": "10:30",
+        "passengers": 180,
+        "departureLatitude": 41.3851,
+        "departureLongitude": 2.1734,
+        "arrivalLatitude": 51.5074,
+        "arrivalLongitude": -0.1278
+      }'
+```
+
+Right now this returns a `500` — the controller throws `UnsupportedOperationException`. Making it
+return a real answer is Task 3.
+
+---
+
+## The Assessment
+
+> ### Flight Feasibility Assessment
+>
+> Build a REST API that determines whether a flight plan is feasible based on a set of business
+> rules.
+>
+> The API receives a flight plan containing:
+>
+> - Flight number
+> - Take-off time
+> - Number of passengers
+> - Departure latitude and longitude
+> - Arrival latitude and longitude
+>
+> The application must calculate the flight distance using the **Haversine formula** and evaluate the
+> flight against the following rules:
+>
+> **Maximum flight range**
+> - Flights with 150 passengers or fewer cannot exceed 12,000 km.
+> - Flights with more than 150 passengers cannot exceed 8,000 km.
+>
+> **Long-distance flights**
+> - Flights longer than 9,000 km must take off between 06:00 and 14:00.
+>
+> **Westbound flights**
+>
+> Flights travelling west must:
+> - take off before 15:00, and
+> - not exceed 3,000 km.
+>
+> The API should return:
+> - whether the flight is feasible;
+> - a list of feedback messages explaining which rules were violated.
+>
+> **Additional expectations:**
+> - Follow clean code principles.
+> - Write unit tests.
+> - Keep the solution maintainable and easy to extend.
+
+---
+
+## What You Get
+
+```
+src/main/java/com/amigoscode/interview/
+├── FlightFeasibilityApplication.java
+└── flight/
+    ├── FlightPlanController.java    ← POST /api/flights/feasibility, body throws (Task 3)
+    ├── FlightPlanRequest.java       ← the request contract, matching the brief's input fields
+    └── FeasibilityResponse.java     ← the response contract: feasible + feedback
+```
+
+The three `flight/` classes exist so your JSON matches a known shape and the interviewer can call
+your endpoint. **Everything else is yours to design and create** — the distance calculation, the
+rules, the domain model, validation, error handling and all the tests.
+
+You are free to restructure, rename and repackage anything, including those three classes, as long as
+the endpoint keeps working.
+
+## What You Build
+
+- `POST /api/flights/feasibility` returns `{ "feasible": true|false, "feedback": [...] }`
+- The Haversine distance calculation (implement it — do not add a geo library)
+- The three rule groups from the brief
+- Unit tests, including the boundaries
+- Whatever structure makes a fourth rule cheap to add
+
+Pick tasks from [`INTERVIEW_TASKS.md`](INTERVIEW_TASKS.md) according to level.
+
+## Notes for Interviewers
+
+The brief is vague in several places on purpose. The strongest signal in this exercise is **whether
+the candidate notices, asks, and then states a decision** rather than guessing silently. Worth
+probing whichever tasks you pick:
+
+- Is a distance exactly equal to a limit allowed, or not? Same question for each time boundary.
+- Which passenger band does exactly 150 fall into?
+- What does "travelling west" actually mean, given only two longitudes?
+- `takeOffTime` is a time with no date and no timezone — 06:00 where?
+- Should one violation stop the evaluation, or should all of them be reported?
+
+None of these have a single correct answer in the brief. A candidate who says "I read it this way,
+here's why, and here's the test that pins it" is doing the job. A candidate who cannot say which way
+they went has not read their own code.
+
+The fastest way to find out whether the design is genuinely extensible is Task 10 — hand them a new
+rule and watch which files they open.

--- a/java/pair-programming/flight-feasibility/mvnw
+++ b/java/pair-programming/flight-feasibility/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/java/pair-programming/flight-feasibility/mvnw.cmd
+++ b/java/pair-programming/flight-feasibility/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/java/pair-programming/flight-feasibility/pom.xml
+++ b/java/pair-programming/flight-feasibility/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.2</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.amigoscode</groupId>
+    <artifactId>flight-feasibility-interview</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>flight-feasibility-interview</name>
+    <description>Flight Feasibility API — Interview Practice Repository</description>
+
+    <properties>
+        <java.version>25</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/java/pair-programming/flight-feasibility/src/main/java/com/amigoscode/interview/FlightFeasibilityApplication.java
+++ b/java/pair-programming/flight-feasibility/src/main/java/com/amigoscode/interview/FlightFeasibilityApplication.java
@@ -1,0 +1,13 @@
+package com.amigoscode.interview;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class FlightFeasibilityApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(FlightFeasibilityApplication.class, args);
+    }
+
+}

--- a/java/pair-programming/flight-feasibility/src/main/java/com/amigoscode/interview/flight/FeasibilityResponse.java
+++ b/java/pair-programming/flight-feasibility/src/main/java/com/amigoscode/interview/flight/FeasibilityResponse.java
@@ -1,0 +1,13 @@
+package com.amigoscode.interview.flight;
+
+import java.util.List;
+
+/**
+ * The answer the brief asks for: whether the flight is feasible, and feedback explaining which
+ * rules were violated.
+ *
+ * @param feasible whether the flight plan passed every rule
+ * @param feedback messages explaining the violations, empty when the flight is feasible
+ */
+public record FeasibilityResponse(boolean feasible, List<String> feedback) {
+}

--- a/java/pair-programming/flight-feasibility/src/main/java/com/amigoscode/interview/flight/FlightPlanController.java
+++ b/java/pair-programming/flight-feasibility/src/main/java/com/amigoscode/interview/flight/FlightPlanController.java
@@ -1,0 +1,20 @@
+package com.amigoscode.interview.flight;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/flights")
+public class FlightPlanController {
+
+    @PostMapping("/feasibility")
+    public FeasibilityResponse assess(@RequestBody FlightPlanRequest request) {
+        System.out.println("Assessing flight " + request.flightNumber());
+
+        // TODO: work out the distance, evaluate the rules from the brief, and return the verdict.
+        throw new UnsupportedOperationException("Not implemented yet — see INTERVIEW_TASKS.md");
+    }
+
+}

--- a/java/pair-programming/flight-feasibility/src/main/java/com/amigoscode/interview/flight/FlightPlanRequest.java
+++ b/java/pair-programming/flight-feasibility/src/main/java/com/amigoscode/interview/flight/FlightPlanRequest.java
@@ -1,0 +1,19 @@
+package com.amigoscode.interview.flight;
+
+import java.time.LocalTime;
+
+/**
+ * The incoming flight plan, as described in the assessment brief.
+ *
+ * <p>The types are boxed on purpose: a field missing from the JSON arrives as {@code null} rather
+ * than silently becoming {@code 0}. What you do about that is up to you.
+ */
+public record FlightPlanRequest(
+        String flightNumber,
+        LocalTime takeOffTime,
+        Integer passengers,
+        Double departureLatitude,
+        Double departureLongitude,
+        Double arrivalLatitude,
+        Double arrivalLongitude) {
+}

--- a/java/pair-programming/flight-feasibility/src/main/resources/application.yml
+++ b/java/pair-programming/flight-feasibility/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  application:
+    name: flight-feasibility
+
+server:
+  port: 8080

--- a/java/pair-programming/flight-feasibility/src/test/java/com/amigoscode/interview/FlightFeasibilityApplicationTests.java
+++ b/java/pair-programming/flight-feasibility/src/test/java/com/amigoscode/interview/FlightFeasibilityApplicationTests.java
@@ -1,0 +1,13 @@
+package com.amigoscode.interview;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class FlightFeasibilityApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}


### PR DESCRIPTION
Adds `java/pair-programming/flight-feasibility` — a **build-from-scratch** exercise based on a real technical assessment.

## What's different about this one

The other projects hand the candidate a working codebase with intentional issues. This one ships **only the HTTP contract**. The candidate implements the Haversine distance calculation, the three rule groups, the domain model, validation and all the tests.

The assessment brief is reproduced **as it was issued** — ambiguities included. It never defines whether a distance exactly equal to a limit is allowed, which passenger band exactly 150 falls into, what "travelling west" means given two longitudes, or what timezone the take-off time is in. Working that out, asking, and committing to a defensible decision is the point of the exercise, so the brief is not "fixed up".

## Contents

| File | What it is |
| --- | --- |
| `README.md` | The brief verbatim, setup, what's provided vs. what they build, and what to probe as interviewer |
| `INTERVIEW_TASKS.md` | 13 tasks — Junior (1-4), Mid (5-9), Senior (10-13) — in the same Context / What to do / Acceptance Criteria / Hints format as the other projects |
| `src/main/.../flight/` | Controller with the endpoint mapped, plus request and response records |

**Task 10** is the one worth protecting time for: the interviewer hands over an unseen rule and watches which files get opened. If the candidate has to edit the service to register it, the extensibility requirement in the brief was not met. The sharpest variant — "no take-offs between 23:00 and 05:00" — spans midnight, so the natural `&&` is always false.

## Stack

Spring Boot 4.0.2 on Java 25, matching `bookstore-api` and `todo-api`. No database, no Lombok, no unused dependencies. `spring-boot-starter-validation` is deliberately left out so adding it is part of Task 8.

## Verified

- `./mvnw clean verify` passes from a clean clone
- App boots in ~0.9s on Java 25; `POST /api/flights/feasibility` is mapped and throws `UnsupportedOperationException` until Task 3
- `"takeOffTime": "10:30"` deserializes into `LocalTime` under Jackson 3 with no `@JsonFormat` needed — confirmed by request, not assumption
- `"25:99"` already returns `400`, which Task 9 builds on

Root `README.md` updated with the new row and a note explaining the format difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4W5FeknJ5dirZMQ1Dcpm2